### PR TITLE
- Added support for encoding / decoding messages generated by the pyt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Python library for encoding and decoding NMEA 2000 frames. The encoding and de
 - **Decode NMEA 2000 frames**: Parse and interpret raw NMEA 2000 data.
 - **Encode NMEA 2000 frames**: Convert structured data back into the NMEA 2000 frame format.
 - **USB client**: Send and receive NMEA 2000 data over CANBUS USB devices like [Waveshare USB-CAN-A](https://www.waveshare.com/wiki/USB-CAN-A)
+- **python-can client**: Send and receive NMEA 2000 data over any generic USB or SocketCAN device supported by python-can
 - **TCP client**: Send and receive NMEA 2000 data over CANBUS TCP devices like:
      - [EBYTE ECAN-W01S](https://www.cdebyte.com/products/ECAN-W01S)
      - [EBYTE ECAN-E01](https://www.cdebyte.com/products/ECAN-E01)
@@ -64,6 +65,27 @@ decoded_frame = decoder.decode_actisense_string(frame_str)
 
 # Print decoded frame
 print(decoded_frame)
+```
+
+### Example reading packets using python-can
+
+```python
+import can
+from nmea2000.decoder import NMEA2000Decoder
+
+# Initialize decoder
+decoder = NMEA2000Decoder()
+
+# Connect to CAN bus (e.g. slcan device on /dev/ttyUSB0)
+bus = can.interface.Bus(interface='slcan', channel="/dev/ttyUSB0", bitrate=250000)
+
+# Decode frames
+for msg in bus:
+    decoded_frame = decoder.decode_python_can(msg)
+
+    # Print decoded frame when ready (fast data intermediate frames return None)
+    if decoded_frame != None:
+        print(decoded_frame)
 ```
 
 ### TCP Client CLI

--- a/nmea2000/ioclient.py
+++ b/nmea2000/ioclient.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import socket

--- a/nmea2000/message.py
+++ b/nmea2000/message.py
@@ -96,7 +96,11 @@ class NMEA2000Message:
             type_obj = type(obj)
             if type_obj is bytes:
                 return obj.hex()
-            raise TypeError
+            else:
+                try:
+                    return str(obj)
+                except Exception:
+                    raise TypeError
         return orjson.dumps(self.__dict__,   default=default).decode()
 
     @staticmethod

--- a/nmea2000/utils.py
+++ b/nmea2000/utils.py
@@ -1,4 +1,5 @@
 # Standard Library Imports
+from __future__ import annotations
 
 from datetime import date, timedelta
 import struct


### PR DESCRIPTION
I added support for encoding / decoding message objects used by the python-can library.  This enables the use of any hardware interface supported by python-can, including common/low-cost USB-CAN devices such as Canable, Seeedstudio, etc. as well as SocketCAN (on Linux or Raspberry Pi).  Tested was conducted with a canable device specifically and a Garmin GPSmap 4208.

I also fixed a couple of bugs that I encountered while trying to integrate the nmea2000 library into a test project.

- Added support for encoding / decoding message objects from the python-can library
- Added example code to the readme
- Fixed union-related syntax errors for python < 3.10
- Fixed decoder to_json failing to serialize timestamps
- Fixed traceback when encode_func() raises an exception