### PR TITLE
Add device API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,63 @@ for msg in bus:
         print(decoded_frame)
 ```
 
+### Simple `N2KDevice` example
+
+If you want to behave like a small NMEA 2000 device instead of just reading frames, `N2KDevice` wraps the transport client, handles address claiming, and lets you send/receive `NMEA2000Message` objects directly:
+
+```python
+import asyncio
+
+from nmea2000.device import N2KDevice
+from nmea2000.message import NMEA2000Field, NMEA2000Message
+
+
+async def handle_received(message: NMEA2000Message) -> None:
+    print(f"received PGN {message.PGN} from source {message.source}")
+
+
+async def main() -> None:
+    device = N2KDevice.for_python_can(
+        interface="socketcan",
+        channel="can0",
+        preferred_address=25,
+        model_id="Python demo device",
+        manufacturer_information="nmea2000 README example",
+    )
+    device.set_receive_callback(handle_received)
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=5)
+
+        await device.send(
+            NMEA2000Message(
+                PGN=127250,
+                id="vesselHeading",
+                priority=2,
+                source=0,  # 0 means "use the address claimed by this device"
+                destination=255,
+                fields=[
+                    NMEA2000Field(id="sid", raw_value=0),
+                    NMEA2000Field(id="heading", value=1.0),
+                    NMEA2000Field(id="deviation", raw_value=0),
+                    NMEA2000Field(id="variation", raw_value=0),
+                    NMEA2000Field(id="reference", raw_value=0),
+                    NMEA2000Field(id="reserved_58", raw_value=0),
+                ],
+            )
+        )
+
+        await asyncio.sleep(10)
+    finally:
+        await device.close()
+
+
+asyncio.run(main())
+```
+
+Use `N2KDevice.for_ebyte(...)`, `N2KDevice.for_yacht_devices(...)`, `N2KDevice.for_waveshare(...)`, or `N2KDevice.for_actisense(...)` if you are connecting through one of those gateways instead of `python-can`.
+
 ### TCP Client CLI
 
 ```bash

--- a/nmea2000/__init__.py
+++ b/nmea2000/__init__.py
@@ -3,5 +3,6 @@ from .encoder import NMEA2000Encoder
 from .consts import FieldTypes, PhysicalQuantities, ManufacturerCodes
 from .message import NMEA2000Message, NMEA2000Field, IsoName
 from .ioclient import EByteNmea2000Gateway, ActisenseNmea2000Gateway, YachtDevicesNmea2000Gateway, WaveShareNmea2000Gateway, PythonCanAsyncIOClient, AsyncIOClient, State
+from .device import N2KDevice
 
-__all__ = ["NMEA2000Decoder", "NMEA2000Encoder", "NMEA2000Message", "NMEA2000Field", "EByteNmea2000Gateway", "ActisenseNmea2000Gateway", "YachtDevicesNmea2000Gateway", "WaveShareNmea2000Gateway", "PythonCanAsyncIOClient", "AsyncIOClient", "FieldTypes", "PhysicalQuantities", "State", "IsoName", "ManufacturerCodes"]
+__all__ = ["NMEA2000Decoder", "NMEA2000Encoder", "NMEA2000Message", "NMEA2000Field", "EByteNmea2000Gateway", "ActisenseNmea2000Gateway", "YachtDevicesNmea2000Gateway", "WaveShareNmea2000Gateway", "PythonCanAsyncIOClient", "AsyncIOClient", "FieldTypes", "PhysicalQuantities", "State", "IsoName", "ManufacturerCodes", "N2KDevice"]

--- a/nmea2000/device.py
+++ b/nmea2000/device.py
@@ -1,0 +1,617 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from dataclasses import dataclass
+from datetime import datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from .ioclient import (
+    ActisenseNmea2000Gateway,
+    AsyncIOClient,
+    EByteNmea2000Gateway,
+    PythonCanAsyncIOClient,
+    State,
+    WaveShareNmea2000Gateway,
+    YachtDevicesNmea2000Gateway,
+)
+from .message import IsoName, NMEA2000Field, NMEA2000Message
+
+logger = logging.getLogger(__name__)
+
+MessageCallback = Callable[[NMEA2000Message], Awaitable[None]]
+StatusCallback = Callable[[State], Awaitable[None]]
+
+MANAGEMENT_PGNS = frozenset({59392, 59904, 60928, 126208, 126464, 126993, 126996, 126998})
+DEFAULT_TRANSMIT_PGNS = (59904, 60928, 126464, 126993, 126996, 126998)
+
+
+@dataclass
+class DiscoveredDevice:
+    source: int
+    last_seen: datetime | None = None
+    address_claim: NMEA2000Message | None = None
+    product_information: NMEA2000Message | None = None
+    configuration_information: NMEA2000Message | None = None
+
+
+class N2KDevice:
+    def __init__(
+        self,
+        client: AsyncIOClient,
+        *,
+        preferred_address: int = 100,
+        unique_number: int | None = None,
+        manufacturer_code: int = 999,
+        device_function: int = 130,
+        device_class: int = 25,
+        device_instance_lower: int = 0,
+        device_instance_upper: int = 0,
+        system_instance: int = 0,
+        industry_group: int = 4,
+        arbitrary_address_capable: bool = True,
+        product_code: int = 667,
+        nmea2000_version: int = 1300,
+        model_id: str = "nmea2000",
+        model_version: str = "nmea2000",
+        model_serial_code: str | None = None,
+        software_version_code: str | None = None,
+        certification_level: int = 0,
+        load_equivalency: int = 1,
+        installation_description1: str = "",
+        installation_description2: str = "",
+        manufacturer_information: str = "",
+        transmit_pgns: list[int] | None = None,
+        address_claim_detection_time: float = 5.0,
+        address_claim_startup_delay: float = 1.0,
+        heartbeat_interval: float = 60.0,
+        persistence_path: str | Path | None = None,
+        persistence_key: str = "default",
+        disable_naks: bool = False,
+    ):
+        self.client = client
+        self.client.set_receive_callback(self._handle_client_message)
+        self.client.set_status_callback(self._handle_client_status)
+
+        self._receive_callback: MessageCallback | None = None
+        self._raw_receive_callback: MessageCallback | None = None
+        self._status_callback: StatusCallback | None = None
+
+        self.disable_naks = disable_naks
+        self.address_claim_detection_time = address_claim_detection_time
+        self.address_claim_startup_delay = address_claim_startup_delay
+        self.heartbeat_interval = heartbeat_interval
+        self._started = False
+        self._ready = False
+        self._ready_event = asyncio.Event()
+        self._startup_task: asyncio.Task[None] | None = None
+        self._claim_ready_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closing = False
+        self.heartbeat_counter = 0
+        self.devices: dict[int, DiscoveredDevice] = {}
+
+        self.persistence_path = self._resolve_persistence_path(persistence_path, persistence_key)
+        persisted = self._load_persistence_data()
+        self.unique_number = unique_number if unique_number is not None else int(persisted.get("uniqueNumber", self._generate_unique_number()))
+        self.address = int(persisted.get("lastAddress", preferred_address))
+
+        self.manufacturer_code = manufacturer_code
+        self.device_function = device_function
+        self.device_class = device_class
+        self.device_instance_lower = device_instance_lower
+        self.device_instance_upper = device_instance_upper
+        self.system_instance = system_instance
+        self.industry_group = industry_group
+        self.arbitrary_address_capable = arbitrary_address_capable
+
+        self.product_code = product_code
+        self.nmea2000_version = nmea2000_version
+        self.model_id = model_id
+        self.model_version = model_version
+        self.model_serial_code = model_serial_code or str(self.unique_number)
+        self.software_version_code = software_version_code or self._get_package_version()
+        self.certification_level = certification_level
+        self.load_equivalency = load_equivalency
+        self.installation_description1 = installation_description1
+        self.installation_description2 = installation_description2
+        self.manufacturer_information = manufacturer_information
+        self.transmit_pgns = sorted(set(transmit_pgns or DEFAULT_TRANSMIT_PGNS))
+
+        self._persist(unique_number=self.unique_number)
+
+    @property
+    def state(self) -> State:
+        return self.client.state
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
+
+    def set_receive_callback(self, callback: Optional[MessageCallback]) -> None:
+        self._receive_callback = callback
+
+    def set_raw_receive_callback(self, callback: Optional[MessageCallback]) -> None:
+        self._raw_receive_callback = callback
+
+    def set_status_callback(self, callback: Optional[StatusCallback]) -> None:
+        self._status_callback = callback
+
+    @classmethod
+    def for_ebyte(
+        cls,
+        host: str,
+        port: int,
+        *,
+        client_options: dict[str, Any] | None = None,
+        **device_options: Any,
+    ) -> "N2KDevice":
+        client = EByteNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
+        return cls(client, **device_options)
+
+    @classmethod
+    def for_yacht_devices(
+        cls,
+        host: str,
+        port: int,
+        *,
+        client_options: dict[str, Any] | None = None,
+        **device_options: Any,
+    ) -> "N2KDevice":
+        client = YachtDevicesNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
+        return cls(client, **device_options)
+
+    @classmethod
+    def for_waveshare(
+        cls,
+        port: str,
+        *,
+        client_options: dict[str, Any] | None = None,
+        **device_options: Any,
+    ) -> "N2KDevice":
+        client = WaveShareNmea2000Gateway(port, **cls._prepare_client_options(client_options))
+        return cls(client, **device_options)
+
+    @classmethod
+    def for_python_can(
+        cls,
+        interface: str,
+        channel: str,
+        *,
+        client_options: dict[str, Any] | None = None,
+        **device_options: Any,
+    ) -> "N2KDevice":
+        client_kwargs = cls._prepare_client_options(client_options)
+        client = PythonCanAsyncIOClient(interface, channel, **client_kwargs)
+        return cls(client, **device_options)
+
+    @classmethod
+    def for_actisense(
+        cls,
+        host: str,
+        port: int,
+        *,
+        client_options: dict[str, Any] | None = None,
+        **device_options: Any,
+    ) -> "N2KDevice":
+        client = ActisenseNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
+        return cls(client, **device_options)
+
+    async def start(self) -> None:
+        self._started = True
+        await self.client.connect()
+
+    async def close(self) -> None:
+        self._closing = True
+        self._started = False
+        self._set_not_ready()
+        await self._cancel_task(self._startup_task)
+        await self._cancel_task(self._claim_ready_task)
+        await self._cancel_task(self._heartbeat_task)
+        await self.client.close()
+
+    async def wait_ready(self, timeout: float | None = None) -> bool:
+        if timeout is None:
+            await self._ready_event.wait()
+            return True
+        await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
+        return True
+
+    async def send(self, nmea2000_message: NMEA2000Message) -> None:
+        if not self.ready:
+            raise RuntimeError("Device has not claimed an address yet")
+        if nmea2000_message.source == 0:
+            nmea2000_message.source = self.address
+        await self.client.send(nmea2000_message)
+
+    async def _handle_client_status(self, state: State) -> None:
+        if state != State.CONNECTED:
+            self._set_not_ready()
+            await self._cancel_task(self._claim_ready_task)
+            await self._cancel_task(self._heartbeat_task)
+
+        if state == State.CONNECTED and self._started and not self._closing:
+            await self._schedule_startup_claim()
+
+        if self._status_callback is not None:
+            try:
+                await self._status_callback(state)
+            except Exception as exc:
+                logger.error("Error in device status callback: %s", exc, exc_info=True)
+
+    async def _handle_client_message(self, message: NMEA2000Message) -> None:
+        self._remember_device(message)
+
+        if self._raw_receive_callback is not None:
+            try:
+                await self._raw_receive_callback(message)
+            except Exception as exc:
+                logger.error("Error in raw receive callback: %s", exc, exc_info=True)
+
+        if message.PGN in MANAGEMENT_PGNS:
+            await self._handle_management_message(message)
+            return
+
+        if self._receive_callback is not None:
+            try:
+                await self._receive_callback(message)
+            except Exception as exc:
+                logger.error("Error in receive callback: %s", exc, exc_info=True)
+
+    async def _handle_management_message(self, message: NMEA2000Message) -> None:
+        if message.PGN == 60928:
+            await self._handle_iso_address_claim(message)
+            return
+
+        if message.PGN == 126996:
+            self._get_or_create_discovered_device(message.source).product_information = message
+            return
+
+        if message.PGN == 126998:
+            self._get_or_create_discovered_device(message.source).configuration_information = message
+            return
+
+        if not self._should_process_management_message(message):
+            return
+
+        if message.PGN == 59904 and self.ready:
+            await self._handle_iso_request(message)
+            return
+
+        if message.PGN == 126208 and self.ready:
+            await self._handle_group_function(message)
+
+    async def _schedule_startup_claim(self) -> None:
+        await self._cancel_task(self._startup_task)
+        self._startup_task = asyncio.create_task(self._startup_claim_sequence())
+
+    async def _startup_claim_sequence(self) -> None:
+        self._set_not_ready()
+        await self._cancel_task(self._claim_ready_task)
+        await self._cancel_task(self._heartbeat_task)
+        await self._send_internal_message(self._build_iso_request_message(60928, source=254))
+        if self.address_claim_startup_delay > 0:
+            await asyncio.sleep(self.address_claim_startup_delay)
+        await self._send_address_claim()
+
+    async def _send_address_claim(self) -> None:
+        if self._address_is_occupied(self.address):
+            self._increase_address()
+
+        await self._send_internal_message(self._build_address_claim_message())
+        await self._cancel_task(self._claim_ready_task)
+        self._claim_ready_task = asyncio.create_task(self._mark_ready_after_claim())
+
+    async def _mark_ready_after_claim(self) -> None:
+        if self.address_claim_detection_time > 0:
+            await asyncio.sleep(self.address_claim_detection_time)
+
+        self._ready = True
+        self._ready_event.set()
+        self._persist(lastAddress=self.address)
+        await self._announce_startup_messages()
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def _announce_startup_messages(self) -> None:
+        await self._send_internal_message(self._build_product_information_message())
+        if self._has_configuration_information():
+            await self._send_internal_message(self._build_configuration_information_message())
+
+    async def _heartbeat_loop(self) -> None:
+        while self._started and not self._closing:
+            await asyncio.sleep(self.heartbeat_interval)
+            if not self._started or self._closing:
+                return
+            if self.ready:
+                await self._send_internal_message(self._build_heartbeat_message())
+
+    async def _handle_iso_request(self, message: NMEA2000Message) -> None:
+        requested_pgn = message.get_field_int_value_by_id("pgn")
+        if requested_pgn == 60928:
+            await self._send_internal_message(self._build_address_claim_message())
+            return
+        if requested_pgn == 126996:
+            await self._send_internal_message(self._build_product_information_message())
+            return
+        if requested_pgn == 126998 and self._has_configuration_information():
+            await self._send_internal_message(self._build_configuration_information_message())
+            return
+        if requested_pgn == 126464:
+            await self._send_internal_message(self._build_pgn_list_message(message.source))
+            return
+        if not self.disable_naks:
+            await self._send_internal_message(self._build_iso_nak_message(message.source, requested_pgn))
+
+    async def _handle_group_function(self, message: NMEA2000Message) -> None:
+        if self.disable_naks:
+            return
+        if message.id not in {"nmeaRequestGroupFunction", "nmeaCommandGroupFunction"}:
+            return
+        requested_pgn = message.get_field_int_value_by_id("pgn")
+        await self._send_internal_message(self._build_group_function_ack_message(message.source, requested_pgn))
+
+    async def _handle_iso_address_claim(self, message: NMEA2000Message) -> None:
+        source = message.source
+        discovered = self._get_or_create_discovered_device(source)
+        discovered.address_claim = message
+
+        if not self.ready or source != self.address:
+            return
+
+        received_name = self._name_value_from_message(message)
+        own_name = self._own_name_value()
+        if own_name < received_name:
+            await self._send_address_claim()
+        elif own_name > received_name:
+            self._increase_address()
+            await self._send_address_claim()
+
+    def _should_process_management_message(self, message: NMEA2000Message) -> bool:
+        return message.destination == 255 or (self.ready and message.destination == self.address)
+
+    def _remember_device(self, message: NMEA2000Message) -> None:
+        discovered = self._get_or_create_discovered_device(message.source)
+        discovered.last_seen = message.timestamp
+
+    def _get_or_create_discovered_device(self, source: int) -> DiscoveredDevice:
+        discovered = self.devices.get(source)
+        if discovered is None:
+            discovered = DiscoveredDevice(source=source)
+            self.devices[source] = discovered
+        return discovered
+
+    def _address_is_occupied(self, address: int) -> bool:
+        discovered = self.devices.get(address)
+        if discovered is None or discovered.address_claim is None:
+            return False
+        return self._name_value_from_message(discovered.address_claim) != self._own_name_value()
+
+    def _increase_address(self) -> None:
+        start_address = self.address
+        while True:
+            self.address = (self.address + 1) % 253
+            if self.address == start_address or not self._address_is_occupied(self.address):
+                return
+
+    def _own_name_value(self) -> int:
+        return self._name_value_from_message(self._build_address_claim_message())
+
+    def _name_value_from_message(self, message: NMEA2000Message) -> int:
+        return IsoName.pack_name_from_message(message)
+
+    async def _send_internal_message(self, message: NMEA2000Message) -> None:
+        await self.client.send(message)
+
+    def _set_not_ready(self) -> None:
+        self._ready = False
+        self._ready_event.clear()
+
+    def _build_iso_request_message(self, requested_pgn: int, *, source: int | None = None, destination: int = 255) -> NMEA2000Message:
+        return NMEA2000Message(
+            PGN=59904,
+            id="isoRequest",
+            description="ISO Request",
+            source=self.address if source is None else source,
+            destination=destination,
+            priority=6,
+            fields=[NMEA2000Field("pgn", value=requested_pgn, raw_value=requested_pgn)],
+        )
+
+    def _build_address_claim_message(self) -> NMEA2000Message:
+        yes_no = 1 if self.arbitrary_address_capable else 0
+        return NMEA2000Message(
+            PGN=60928,
+            id="isoAddressClaim",
+            description="ISO Address Claim",
+            source=self.address,
+            destination=255,
+            priority=6,
+            fields=[
+                NMEA2000Field("uniqueNumber", value=self.unique_number, raw_value=self.unique_number),
+                NMEA2000Field("manufacturerCode", value=self.manufacturer_code, raw_value=self.manufacturer_code),
+                NMEA2000Field("deviceInstanceLower", value=self.device_instance_lower, raw_value=self.device_instance_lower),
+                NMEA2000Field("deviceInstanceUpper", value=self.device_instance_upper, raw_value=self.device_instance_upper),
+                NMEA2000Field("deviceFunction", value=self.device_function, raw_value=self.device_function),
+                NMEA2000Field("spare", value=1, raw_value=1),
+                NMEA2000Field("deviceClass", value=self.device_class, raw_value=self.device_class),
+                NMEA2000Field("systemInstance", value=self.system_instance, raw_value=self.system_instance),
+                NMEA2000Field("industryGroup", value=self.industry_group, raw_value=self.industry_group),
+                NMEA2000Field("arbitraryAddressCapable", value=yes_no, raw_value=yes_no),
+            ],
+        )
+
+    def _build_heartbeat_message(self) -> NMEA2000Message:
+        self.heartbeat_counter = (self.heartbeat_counter + 1) % 253
+        return NMEA2000Message(
+            PGN=126993,
+            id="heartbeat",
+            description="Heartbeat",
+            source=self.address,
+            destination=255,
+            priority=6,
+            fields=[
+                NMEA2000Field("dataTransmitOffset", value=self.heartbeat_interval, raw_value=self.heartbeat_interval),
+                NMEA2000Field("sequenceCounter", value=self.heartbeat_counter, raw_value=self.heartbeat_counter),
+                NMEA2000Field("controller1State", value=None, raw_value=3),
+                NMEA2000Field("controller2State", value=None, raw_value=3),
+                NMEA2000Field("equipmentStatus", value=0, raw_value=0),
+                NMEA2000Field("reserved_30", value=None, raw_value=(1 << 34) - 1),
+            ],
+        )
+
+    def _build_product_information_message(self) -> NMEA2000Message:
+        return NMEA2000Message(
+            PGN=126996,
+            id="productInformation",
+            description="Product Information",
+            source=self.address,
+            destination=255,
+            priority=6,
+            fields=[
+                NMEA2000Field(
+                    "nmea2000Version",
+                    value=self.nmea2000_version / 1000,
+                    raw_value=self.nmea2000_version,
+                ),
+                NMEA2000Field("productCode", value=self.product_code, raw_value=self.product_code),
+                NMEA2000Field("modelId", value=self.model_id, raw_value=self.model_id),
+                NMEA2000Field("softwareVersionCode", value=self.software_version_code, raw_value=self.software_version_code),
+                NMEA2000Field("modelVersion", value=self.model_version, raw_value=self.model_version),
+                NMEA2000Field("modelSerialCode", value=self.model_serial_code, raw_value=self.model_serial_code),
+                NMEA2000Field("certificationLevel", value=self.certification_level, raw_value=self.certification_level),
+                NMEA2000Field("loadEquivalency", value=self.load_equivalency, raw_value=self.load_equivalency),
+            ],
+        )
+
+    def _build_configuration_information_message(self) -> NMEA2000Message:
+        return NMEA2000Message(
+            PGN=126998,
+            id="configurationInformation",
+            description="Configuration Information",
+            source=self.address,
+            destination=255,
+            priority=6,
+            fields=[
+                NMEA2000Field("installationDescription1", value=self.installation_description1, raw_value=self.installation_description1),
+                NMEA2000Field("installationDescription2", value=self.installation_description2, raw_value=self.installation_description2),
+                NMEA2000Field("manufacturerInformation", value=self.manufacturer_information, raw_value=self.manufacturer_information),
+            ],
+        )
+
+    def _build_iso_nak_message(self, destination: int, requested_pgn: int) -> NMEA2000Message:
+        return NMEA2000Message(
+            PGN=59392,
+            id="isoAcknowledgement",
+            description="ISO Acknowledgement",
+            source=self.address,
+            destination=destination,
+            priority=6,
+            fields=[
+                NMEA2000Field("control", value=1, raw_value=1),
+                NMEA2000Field("groupFunction", value=255, raw_value=255),
+                NMEA2000Field("reserved_16", value=0, raw_value=0),
+                NMEA2000Field("pgn", value=requested_pgn, raw_value=requested_pgn),
+            ],
+        )
+
+    def _build_group_function_ack_message(self, destination: int, requested_pgn: int) -> NMEA2000Message:
+        return NMEA2000Message(
+            PGN=126208,
+            id="nmeaAcknowledgeGroupFunction",
+            description="NMEA - Acknowledge group function",
+            source=self.address,
+            destination=destination,
+            priority=6,
+            fields=[
+                NMEA2000Field("pgn", value=requested_pgn, raw_value=requested_pgn),
+                NMEA2000Field("pgnErrorCode", value=1, raw_value=1),
+                NMEA2000Field("transmissionIntervalPriorityErrorCode", value=0, raw_value=0),
+                NMEA2000Field("numberOfParameters", value=0, raw_value=0),
+                NMEA2000Field("parameter", value=0, raw_value=0),
+            ],
+        )
+
+    def _build_pgn_list_message(self, destination: int) -> NMEA2000Message:
+        payload = b"".join(pgn.to_bytes(3, byteorder="little", signed=False) for pgn in self.transmit_pgns)
+        return NMEA2000Message(
+            PGN=126464,
+            id="pgnListTransmitAndReceive",
+            description="PGN List (Transmit and Receive)",
+            source=self.address,
+            destination=destination,
+            priority=6,
+            fields=[
+                NMEA2000Field("functionCode", value=0, raw_value=0),
+                NMEA2000Field("data", value=payload, raw_value=payload),
+            ],
+        )
+
+    def _has_configuration_information(self) -> bool:
+        return any(
+            [
+                self.installation_description1,
+                self.installation_description2,
+                self.manufacturer_information,
+            ]
+        )
+
+    def _resolve_persistence_path(self, persistence_path: str | Path | None, persistence_key: str) -> Path:
+        if persistence_path is not None:
+            return Path(persistence_path)
+        return Path.home() / ".nmea2000" / f"{persistence_key}.json"
+
+    def _load_persistence_data(self) -> dict[str, Any]:
+        if not self.persistence_path.exists():
+            return {}
+        try:
+            return json.loads(self.persistence_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to read persistence file %s: %s", self.persistence_path, exc)
+            return {}
+
+    def _persist(self, **values: Any) -> None:
+        current = self._load_persistence_data()
+        current.update(values)
+        self.persistence_path.parent.mkdir(parents=True, exist_ok=True)
+        self.persistence_path.write_text(json.dumps(current, indent=2, sort_keys=True), encoding="utf-8")
+
+    def _generate_unique_number(self) -> int:
+        return random.randint(0, 2097151)
+
+    def _get_package_version(self) -> str:
+        try:
+            return version("nmea2000")
+        except PackageNotFoundError:
+            return "nmea2000"
+
+    @staticmethod
+    async def _cancel_task(task: asyncio.Task[None] | None) -> None:
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            return
+
+    @staticmethod
+    def _prepare_client_options(client_options: dict[str, Any] | None) -> dict[str, Any]:
+        options = dict(client_options or {})
+        include_pgns = list(options.get("include_pgns", []))
+        exclude_pgns = list(options.get("exclude_pgns", []))
+
+        for pgn in MANAGEMENT_PGNS:
+            while pgn in exclude_pgns:
+                exclude_pgns.remove(pgn)
+            if include_pgns and pgn not in include_pgns:
+                include_pgns.append(pgn)
+
+        options["include_pgns"] = include_pgns
+        options["exclude_pgns"] = exclude_pgns
+        options["build_network_map"] = True
+        return options

--- a/nmea2000/device.py
+++ b/nmea2000/device.py
@@ -32,6 +32,8 @@ DEFAULT_TRANSMIT_PGNS = (59904, 60928, 126464, 126993, 126996, 126998)
 
 @dataclass
 class DiscoveredDevice:
+    """State tracked for another device observed on the NMEA 2000 bus."""
+
     source: int
     last_seen: datetime | None = None
     address_claim: NMEA2000Message | None = None
@@ -40,19 +42,21 @@ class DiscoveredDevice:
 
 
 class N2KDevice:
+    """High-level async NMEA 2000 device wrapper with address-claim handling."""
+
     def __init__(
         self,
         client: AsyncIOClient,
         *,
-        preferred_address: int = 100,
-        unique_number: int | None = None,
-        manufacturer_code: int = 999,
-        device_function: int = 130,
-        device_class: int = 25,
+        preferred_address: int = 100, # A commonly unused address
+        unique_number: int | None = None, 
+        manufacturer_code: int = 999, # A nonexistent manufacturer code
+        device_function: int = 130, # PC Gateway
+        device_class: int = 25, # Inter/Intra Network Device
         device_instance_lower: int = 0,
         device_instance_upper: int = 0,
         system_instance: int = 0,
-        industry_group: int = 4,
+        industry_group: int = 4, # Marine
         arbitrary_address_capable: bool = True,
         product_code: int = 667,
         nmea2000_version: int = 1300,
@@ -73,6 +77,7 @@ class N2KDevice:
         persistence_key: str = "default",
         disable_naks: bool = False,
     ):
+        """Create a device around an async transport client and local device identity."""
         self.client = client
         self.client.set_receive_callback(self._handle_client_message)
         self.client.set_status_callback(self._handle_client_status)
@@ -108,6 +113,7 @@ class N2KDevice:
         self.system_instance = system_instance
         self.industry_group = industry_group
         self.arbitrary_address_capable = arbitrary_address_capable
+        self._own_name = IsoName.pack_name_from_message(self._build_address_claim_message())
 
         self.product_code = product_code
         self.nmea2000_version = nmea2000_version
@@ -126,19 +132,24 @@ class N2KDevice:
 
     @property
     def state(self) -> State:
+        """Return the current connection state of the underlying client."""
         return self.client.state
 
     @property
     def ready(self) -> bool:
+        """Return ``True`` once the device has claimed an address and is ready to send."""
         return self._ready
 
     def set_receive_callback(self, callback: Optional[MessageCallback]) -> None:
+        """Register a callback for non-management messages delivered to this device."""
         self._receive_callback = callback
 
     def set_raw_receive_callback(self, callback: Optional[MessageCallback]) -> None:
+        """Register a callback for every received message before management handling."""
         self._raw_receive_callback = callback
 
     def set_status_callback(self, callback: Optional[StatusCallback]) -> None:
+        """Register a callback for underlying client state changes."""
         self._status_callback = callback
 
     @classmethod
@@ -150,6 +161,7 @@ class N2KDevice:
         client_options: dict[str, Any] | None = None,
         **device_options: Any,
     ) -> "N2KDevice":
+        """Create a device that communicates through an EByte TCP gateway."""
         client = EByteNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
         return cls(client, **device_options)
 
@@ -162,6 +174,7 @@ class N2KDevice:
         client_options: dict[str, Any] | None = None,
         **device_options: Any,
     ) -> "N2KDevice":
+        """Create a device that communicates through a Yacht Devices gateway."""
         client = YachtDevicesNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
         return cls(client, **device_options)
 
@@ -173,6 +186,7 @@ class N2KDevice:
         client_options: dict[str, Any] | None = None,
         **device_options: Any,
     ) -> "N2KDevice":
+        """Create a device that communicates through a Waveshare USB-CAN gateway."""
         client = WaveShareNmea2000Gateway(port, **cls._prepare_client_options(client_options))
         return cls(client, **device_options)
 
@@ -185,6 +199,7 @@ class N2KDevice:
         client_options: dict[str, Any] | None = None,
         **device_options: Any,
     ) -> "N2KDevice":
+        """Create a device that communicates through a ``python-can`` interface."""
         client_kwargs = cls._prepare_client_options(client_options)
         client = PythonCanAsyncIOClient(interface, channel, **client_kwargs)
         return cls(client, **device_options)
@@ -198,14 +213,17 @@ class N2KDevice:
         client_options: dict[str, Any] | None = None,
         **device_options: Any,
     ) -> "N2KDevice":
+        """Create a device that communicates through an Actisense TCP gateway."""
         client = ActisenseNmea2000Gateway(host, port, **cls._prepare_client_options(client_options))
         return cls(client, **device_options)
 
     async def start(self) -> None:
+        """Connect the client and begin the device startup/address-claim sequence."""
         self._started = True
         await self.client.connect()
 
     async def close(self) -> None:
+        """Stop background tasks, mark the device not ready, and close the client."""
         self._closing = True
         self._started = False
         self._set_not_ready()
@@ -215,6 +233,7 @@ class N2KDevice:
         await self.client.close()
 
     async def wait_ready(self, timeout: float | None = None) -> bool:
+        """Wait until the device has successfully claimed an address."""
         if timeout is None:
             await self._ready_event.wait()
             return True
@@ -222,6 +241,7 @@ class N2KDevice:
         return True
 
     async def send(self, nmea2000_message: NMEA2000Message) -> None:
+        """Send a message, substituting the claimed source address when ``source`` is ``0``."""
         if not self.ready:
             raise RuntimeError("Device has not claimed an address yet")
         if nmea2000_message.source == 0:
@@ -293,7 +313,7 @@ class N2KDevice:
         self._set_not_ready()
         await self._cancel_task(self._claim_ready_task)
         await self._cancel_task(self._heartbeat_task)
-        await self._send_internal_message(self._build_iso_request_message(60928, source=254))
+        await self.client.send(self._build_iso_request_message(60928, source=254))
         if self.address_claim_startup_delay > 0:
             await asyncio.sleep(self.address_claim_startup_delay)
         await self._send_address_claim()
@@ -302,7 +322,7 @@ class N2KDevice:
         if self._address_is_occupied(self.address):
             self._increase_address()
 
-        await self._send_internal_message(self._build_address_claim_message())
+        await self.client.send(self._build_address_claim_message())
         await self._cancel_task(self._claim_ready_task)
         self._claim_ready_task = asyncio.create_task(self._mark_ready_after_claim())
 
@@ -318,9 +338,9 @@ class N2KDevice:
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
     async def _announce_startup_messages(self) -> None:
-        await self._send_internal_message(self._build_product_information_message())
+        await self.client.send(self._build_product_information_message())
         if self._has_configuration_information():
-            await self._send_internal_message(self._build_configuration_information_message())
+            await self.client.send(self._build_configuration_information_message())
 
     async def _heartbeat_loop(self) -> None:
         while self._started and not self._closing:
@@ -328,24 +348,24 @@ class N2KDevice:
             if not self._started or self._closing:
                 return
             if self.ready:
-                await self._send_internal_message(self._build_heartbeat_message())
+                await self.client.send(self._build_heartbeat_message())
 
     async def _handle_iso_request(self, message: NMEA2000Message) -> None:
         requested_pgn = message.get_field_int_value_by_id("pgn")
         if requested_pgn == 60928:
-            await self._send_internal_message(self._build_address_claim_message())
+            await self.client.send(self._build_address_claim_message())
             return
         if requested_pgn == 126996:
-            await self._send_internal_message(self._build_product_information_message())
+            await self.client.send(self._build_product_information_message())
             return
         if requested_pgn == 126998 and self._has_configuration_information():
-            await self._send_internal_message(self._build_configuration_information_message())
+            await self.client.send(self._build_configuration_information_message())
             return
         if requested_pgn == 126464:
-            await self._send_internal_message(self._build_pgn_list_message(message.source))
+            await self.client.send(self._build_pgn_list_message(message.source))
             return
         if not self.disable_naks:
-            await self._send_internal_message(self._build_iso_nak_message(message.source, requested_pgn))
+            await self.client.send(self._build_iso_nak_message(message.source, requested_pgn))
 
     async def _handle_group_function(self, message: NMEA2000Message) -> None:
         if self.disable_naks:
@@ -353,21 +373,21 @@ class N2KDevice:
         if message.id not in {"nmeaRequestGroupFunction", "nmeaCommandGroupFunction"}:
             return
         requested_pgn = message.get_field_int_value_by_id("pgn")
-        await self._send_internal_message(self._build_group_function_ack_message(message.source, requested_pgn))
+        await self.client.send(self._build_group_function_ack_message(message.source, requested_pgn))
 
     async def _handle_iso_address_claim(self, message: NMEA2000Message) -> None:
         source = message.source
-        discovered = self._get_or_create_discovered_device(source)
-        discovered.address_claim = message
-
         if not self.ready or source != self.address:
+            discovered = self._get_or_create_discovered_device(source)
+            discovered.address_claim = message
             return
 
-        received_name = self._name_value_from_message(message)
-        own_name = self._own_name_value()
-        if own_name < received_name:
+        received_name = IsoName.pack_name_from_message(message)
+        if self._own_name < received_name:
             await self._send_address_claim()
-        elif own_name > received_name:
+        elif self._own_name > received_name:
+            discovered = self._get_or_create_discovered_device(source)
+            discovered.address_claim = message
             self._increase_address()
             await self._send_address_claim()
 
@@ -389,7 +409,7 @@ class N2KDevice:
         discovered = self.devices.get(address)
         if discovered is None or discovered.address_claim is None:
             return False
-        return self._name_value_from_message(discovered.address_claim) != self._own_name_value()
+        return IsoName.pack_name_from_message(discovered.address_claim) != self._own_name
 
     def _increase_address(self) -> None:
         start_address = self.address
@@ -397,15 +417,6 @@ class N2KDevice:
             self.address = (self.address + 1) % 253
             if self.address == start_address or not self._address_is_occupied(self.address):
                 return
-
-    def _own_name_value(self) -> int:
-        return self._name_value_from_message(self._build_address_claim_message())
-
-    def _name_value_from_message(self, message: NMEA2000Message) -> int:
-        return IsoName.pack_name_from_message(message)
-
-    async def _send_internal_message(self, message: NMEA2000Message) -> None:
-        await self.client.send(message)
 
     def _set_not_ready(self) -> None:
         self._ready = False

--- a/nmea2000/device.py
+++ b/nmea2000/device.py
@@ -27,7 +27,6 @@ MessageCallback = Callable[[NMEA2000Message], Awaitable[None]]
 StatusCallback = Callable[[State], Awaitable[None]]
 
 MANAGEMENT_PGNS = frozenset({59392, 59904, 60928, 126208, 126464, 126993, 126996, 126998})
-DEFAULT_TRANSMIT_PGNS = (59904, 60928, 126464, 126993, 126996, 126998)
 
 
 @dataclass
@@ -126,7 +125,7 @@ class N2KDevice:
         self.installation_description1 = installation_description1
         self.installation_description2 = installation_description2
         self.manufacturer_information = manufacturer_information
-        self.transmit_pgns = sorted(set(transmit_pgns or DEFAULT_TRANSMIT_PGNS))
+        self.transmit_pgns = sorted(set(transmit_pgns or ()).union(MANAGEMENT_PGNS))
 
         self._persist(unique_number=self.unique_number)
 

--- a/nmea2000/ioclient.py
+++ b/nmea2000/ioclient.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 import socket
 from enum import Enum
-from typing import Callable, Awaitable, Optional
+from typing import Callable, Awaitable, Optional, Sequence
 import serial_asyncio
 import can.cli
 import can.interface
+import can.message
 from tenacity import stop_never, wait_exponential, retry_if_exception_type
 from tenacity.asyncio import AsyncRetrying
 from abc import ABC, abstractmethod
@@ -16,6 +17,8 @@ from .decoder import NMEA2000Decoder, InvalidFrameError
 from .encoder import NMEA2000Encoder
 from .input_formats import N2KFormat
 from .message import NMEA2000Message
+
+EncodedMessage = bytes | can.message.Message
 
 
 def _configure_tcp_keepalive(sock: socket.socket) -> None:
@@ -83,9 +86,25 @@ class AsyncIOClient(ABC):
         pass
 
     @abstractmethod
-    def _encode_impl(self, nmea2000Message: NMEA2000Message) -> list[bytes]:
+    def _encode_impl(self, nmea2000Message: NMEA2000Message) -> Sequence[EncodedMessage]:
         """Subclasses must implement."""
         pass
+
+    async def _send_impl(self, encoded_message: EncodedMessage):
+        """Send an already encoded message using the transport's native writer."""
+        if not isinstance(encoded_message, bytes):
+            raise TypeError("Stream transports must encode messages as bytes.")
+
+        writer = self.writer
+        if writer is None:
+            raise RuntimeError("Client is not connected to a writable stream.")
+
+        writer.write(encoded_message)
+        await writer.drain()
+
+    def _should_reconnect_on_send_error(self, error: Exception) -> bool:
+        """Whether a send failure should trigger reconnect handling."""
+        return True
 
     def __init__(self, 
                  exclude_pgns:list[int | str], 
@@ -272,20 +291,27 @@ class AsyncIOClient(ABC):
             nmea2000Message: The NMEA2000Message object to send.
         """
         try:
-            msgs = self._encode_impl(nmea2000Message)
-            assert self.writer is not None
-            for msg in msgs:
-                self.writer.write(msg)
-                await self.writer.drain()
-                self.logger.debug(f"Sent: {msg.hex()}")
-
+            msgs = tuple(self._encode_impl(nmea2000Message))
         except ValueError as ve:
-                self.logger.warning(f"Failed to encode message. Error {ve}")
+            self.logger.warning("Failed to encode message. Error %s", ve)
+            return
+
+        try:
+            for msg in msgs:
+                await self._send_impl(msg)
+                if isinstance(msg, bytes):
+                    self.logger.debug("Sent: %s", msg.hex())
+                else:
+                    self.logger.debug("Sent: %s", msg)
         except Exception as ex:
             if self._state != State.CLOSED:
-                self.logger.error(f"Connection lost while sending. Error {ex}. Reconnecting...", exc_info=True)
-                await self._update_state(State.DISCONNECTED)
-                asyncio.create_task(self.connect())
+                if self._should_reconnect_on_send_error(ex):
+                    self.logger.error("Connection lost while sending. Error %s. Reconnecting...", ex, exc_info=True)
+                    await self._update_state(State.DISCONNECTED)
+                    asyncio.create_task(self.connect())
+                else:
+                    self.logger.warning("Send failed without reconnecting. Error %s", ex, exc_info=True)
+            raise
 
     async def close(self):
         """Close the connection and terminate the client.
@@ -770,6 +796,9 @@ class PythonCanAsyncIOClient(AsyncIOClient):
                  dump_to_file: str | None = None,
                  dump_pgns: list[int | str] = [],
                  build_network_map: bool = False,
+                 send_timeout: float = 0.1,
+                 send_retry_count: int = 3,
+                 send_retry_delay: float = 0.05,
                  **kwargs):
         """Initialize a python-can NMEA2000 client.
 
@@ -790,6 +819,9 @@ class PythonCanAsyncIOClient(AsyncIOClient):
             seed_network_map=True)
         self.interface = interface
         self.channel = channel
+        self.send_timeout = send_timeout
+        self.send_retry_count = send_retry_count
+        self.send_retry_delay = send_retry_delay
         self.can_options = kwargs
 
     async def _connect_impl(self):
@@ -801,10 +833,12 @@ class PythonCanAsyncIOClient(AsyncIOClient):
 
     async def _receive_impl(self):
         """Receive data from the CAN device using non-blocking poll."""
+        received_any = False
         while True:
             msg = self.bus.recv(timeout=0)
             if msg is None:
                 break
+            received_any = True
 
             self.logger.debug("Received: %s", msg)
             decoded_frame = None
@@ -817,6 +851,59 @@ class PythonCanAsyncIOClient(AsyncIOClient):
             if decoded_frame is not None:
                 await self.queue.put(decoded_frame)
 
+        await asyncio.sleep(0 if received_any else 0.01)
+
     def _encode_impl(self, nmea2000Message: NMEA2000Message) -> list:
         """Encode a NMEA2000 message for python-can device."""
         return self.encoder.encode(nmea2000Message, output_format=N2KFormat.PYTHON_CAN)
+
+    @staticmethod
+    def _is_transient_send_error(error: Exception) -> bool:
+        if not isinstance(error, can.CanOperationError):
+            return False
+
+        error_text = str(error).lower()
+        return (
+            error.error_code == 105
+            or "no buffer space available" in error_text
+            or "transmit buffer full" in error_text
+            or "buffer full" in error_text
+        )
+
+    def _should_reconnect_on_send_error(self, error: Exception) -> bool:
+        return not self._is_transient_send_error(error)
+
+    async def _send_impl(self, encoded_message: EncodedMessage):
+        """Send an encoded python-can message over the CAN bus."""
+        if not isinstance(encoded_message, can.message.Message):
+            raise TypeError("python-can transport requires can.Message objects.")
+
+        bus = getattr(self, "bus", None)
+        if bus is None:
+            raise RuntimeError("Client is not connected to a CAN bus.")
+
+        attempts = self.send_retry_count + 1
+        for attempt in range(1, attempts + 1):
+            try:
+                bus.send(encoded_message, timeout=self.send_timeout)
+                return
+            except can.CanOperationError as error:
+                if not self._is_transient_send_error(error) or attempt == attempts:
+                    raise
+
+                self.logger.warning(
+                    "python-can transmit queue full, retrying send (%s/%s) in %.2fs",
+                    attempt,
+                    attempts,
+                    self.send_retry_delay,
+                    exc_info=error
+                )
+                await asyncio.sleep(self.send_retry_delay)
+
+    async def close(self):
+        bus = getattr(self, "bus", None)
+        try:
+            await super().close()
+        finally:
+            if bus is not None:
+                bus.shutdown()

--- a/nmea2000/ioclient.py
+++ b/nmea2000/ioclient.py
@@ -823,6 +823,7 @@ class PythonCanAsyncIOClient(AsyncIOClient):
         self.send_retry_count = send_retry_count
         self.send_retry_delay = send_retry_delay
         self.can_options = kwargs
+        self.bus: can.interface.Bus | None = None
 
     async def _connect_impl(self):
         """Connect to the CAN device via python-can."""
@@ -878,14 +879,13 @@ class PythonCanAsyncIOClient(AsyncIOClient):
         if not isinstance(encoded_message, can.message.Message):
             raise TypeError("python-can transport requires can.Message objects.")
 
-        bus = getattr(self, "bus", None)
-        if bus is None:
+        if self.bus is None:
             raise RuntimeError("Client is not connected to a CAN bus.")
 
         attempts = self.send_retry_count + 1
         for attempt in range(1, attempts + 1):
             try:
-                bus.send(encoded_message, timeout=self.send_timeout)
+                self.bus.send(encoded_message, timeout=self.send_timeout)
                 return
             except can.CanOperationError as error:
                 if not self._is_transient_send_error(error) or attempt == attempts:
@@ -901,9 +901,8 @@ class PythonCanAsyncIOClient(AsyncIOClient):
                 await asyncio.sleep(self.send_retry_delay)
 
     async def close(self):
-        bus = getattr(self, "bus", None)
         try:
             await super().close()
         finally:
-            if bus is not None:
-                bus.shutdown()
+            if self.bus is not None:
+                self.bus.shutdown()

--- a/nmea2000/message.py
+++ b/nmea2000/message.py
@@ -148,6 +148,32 @@ class NMEA2000Message:
         if not isinstance(field.value, str):
             raise ValueError(f"PGN: {self.id}: Field with id '{id}' is not a string. It is {type(field.value).__name__}.")
         return field.value
+
+    def get_field_raw_int_by_id(self, id: str, default_value: int | None = None) -> int:
+        field = self.get_field_by_id(id)
+        if isinstance(field.raw_value, int):
+            return field.raw_value
+        if isinstance(field.value, int):
+            return field.value
+        if default_value is not None:
+            return default_value
+        raise ValueError(
+            f"PGN: {self.id}: Field with id '{id}' does not have an integer raw value."
+        )
+
+    def get_field_display_string_by_id(self, id: str) -> str:
+        field = self.get_field_by_id(id)
+        if isinstance(field.value, str):
+            return field.value
+        if isinstance(field.raw_value, str):
+            return field.raw_value
+        if isinstance(field.raw_value, int):
+            return str(field.raw_value)
+        if isinstance(field.value, int):
+            return str(field.value)
+        raise ValueError(
+            f"PGN: {self.id}: Field with id '{id}' does not have a string display value."
+        )
     
 # NMEA2000Field class represents a single NMEA 2000 field
 @dataclass
@@ -216,49 +242,17 @@ class IsoName:
                 the NAME is packed from the message fields.
         """
         self.name = self.pack_name_from_message(message) if name is None else name
-        self.unique_number = self._get_field_raw_int(message, "uniqueNumber", 0)
-        self.manufacturer_code = self._get_field_display_string(message, "manufacturerCode")
+        self.unique_number = message.get_field_raw_int_by_id("uniqueNumber", 0)
+        self.manufacturer_code = message.get_field_display_string_by_id("manufacturerCode")
         self.device_instance = (
-            self._get_field_raw_int(message, "deviceInstanceUpper", 0) << 3
-        ) | self._get_field_raw_int(message, "deviceInstanceLower", 0)
-        self.device_function = self._get_field_display_string(message, "deviceFunction")
-        self.device_class = self._get_field_display_string(message, "deviceClass")
-        self.system_instance = self._get_field_raw_int(message, "systemInstance", 0)
-        self.industry_group = self._get_field_display_string(message, "industryGroup")
+            message.get_field_raw_int_by_id("deviceInstanceUpper", 0) << 3
+        ) | message.get_field_raw_int_by_id("deviceInstanceLower", 0)
+        self.device_function = message.get_field_display_string_by_id("deviceFunction")
+        self.device_class = message.get_field_display_string_by_id("deviceClass")
+        self.system_instance = message.get_field_raw_int_by_id("systemInstance", 0)
+        self.industry_group = message.get_field_display_string_by_id("industryGroup")
         self.arbitrary_address_capable = bool(
-            self._get_field_raw_int(message, "arbitraryAddressCapable", 0)
-        )
-
-    @staticmethod
-    def _get_field_raw_int(
-        message: NMEA2000Message,
-        field_id: str,
-        default: int | None = None,
-    ) -> int:
-        field = message.get_field_by_id(field_id)
-        if isinstance(field.raw_value, int):
-            return field.raw_value
-        if isinstance(field.value, int):
-            return field.value
-        if default is not None:
-            return default
-        raise ValueError(
-            f"PGN: {message.id}: Field with id '{field_id}' does not have an integer raw value."
-        )
-
-    @staticmethod
-    def _get_field_display_string(message: NMEA2000Message, field_id: str) -> str:
-        field = message.get_field_by_id(field_id)
-        if isinstance(field.value, str):
-            return field.value
-        if isinstance(field.raw_value, str):
-            return field.raw_value
-        if isinstance(field.raw_value, int):
-            return str(field.raw_value)
-        if isinstance(field.value, int):
-            return str(field.value)
-        raise ValueError(
-            f"PGN: {message.id}: Field with id '{field_id}' does not have a string display value."
+            message.get_field_raw_int_by_id("arbitraryAddressCapable", 0)
         )
 
     @staticmethod
@@ -276,17 +270,17 @@ class IsoName:
     def pack_name_from_message(cls, message: NMEA2000Message) -> int:
         """Pack the ISO Address Claim fields into the canonical 64-bit NAME integer."""
         return (
-            cls._pack_name_field(cls._get_field_raw_int(message, "uniqueNumber", 0), 21, 0, "uniqueNumber")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "manufacturerCode", 0), 11, 21, "manufacturerCode")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceInstanceLower", 0), 3, 32, "deviceInstanceLower")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceInstanceUpper", 0), 5, 35, "deviceInstanceUpper")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceFunction", 0), 8, 40, "deviceFunction")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "spare", 0), 1, 48, "spare")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceClass", 0), 7, 49, "deviceClass")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "systemInstance", 0), 4, 56, "systemInstance")
-            | cls._pack_name_field(cls._get_field_raw_int(message, "industryGroup", 0), 3, 60, "industryGroup")
+            cls._pack_name_field(message.get_field_raw_int_by_id("uniqueNumber", 0), 21, 0, "uniqueNumber")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("manufacturerCode", 0), 11, 21, "manufacturerCode")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("deviceInstanceLower", 0), 3, 32, "deviceInstanceLower")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("deviceInstanceUpper", 0), 5, 35, "deviceInstanceUpper")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("deviceFunction", 0), 8, 40, "deviceFunction")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("spare", 0), 1, 48, "spare")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("deviceClass", 0), 7, 49, "deviceClass")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("systemInstance", 0), 4, 56, "systemInstance")
+            | cls._pack_name_field(message.get_field_raw_int_by_id("industryGroup", 0), 3, 60, "industryGroup")
             | cls._pack_name_field(
-                cls._get_field_raw_int(message, "arbitraryAddressCapable", 0),
+                message.get_field_raw_int_by_id("arbitraryAddressCapable", 0),
                 1,
                 63,
                 "arbitraryAddressCapable",

--- a/nmea2000/message.py
+++ b/nmea2000/message.py
@@ -206,25 +206,96 @@ class IsoName:
     arbitrary_address_capable: bool
     name: int
 
-    def __init__(self, message: NMEA2000Message, name: int):
+    def __init__(self, message: NMEA2000Message, name: int | None = None):
         """
         Initialize an IsoName object from an NMEA2000Message.
 
         Args:
             message: An NMEA2000Message object containing the NAME field data.
-            name: The 64-bit NAME field value as an integer.
+            name: The optional 64-bit NAME field value as an integer. When omitted,
+                the NAME is packed from the message fields.
         """
-        self.name = name
-        self.unique_number = message.get_field_int_value_by_id('uniqueNumber', 0)
-        self.manufacturer_code = message.get_field_str_value_by_id('manufacturerCode')  # type: ignore
+        self.name = self.pack_name_from_message(message) if name is None else name
+        self.unique_number = self._get_field_raw_int(message, "uniqueNumber", 0)
+        self.manufacturer_code = self._get_field_display_string(message, "manufacturerCode")
         self.device_instance = (
-            message.get_field_int_value_by_id('deviceInstanceUpper', 0) << 3
-        ) | message.get_field_int_value_by_id('deviceInstanceLower', 0)
-        self.device_function = message.get_field_str_value_by_id('deviceFunction')  # type: ignore
-        self.device_class = message.get_field_str_value_by_id('deviceClass')  # type: ignore
-        self.system_instance = message.get_field_int_value_by_id('systemInstance', 0)
-        self.industry_group = message.get_field_str_value_by_id('industryGroup')  # type: ignore
-        self.arbitrary_address_capable = message.get_field_str_value_by_id('arbitraryAddressCapable') == "Yes"
+            self._get_field_raw_int(message, "deviceInstanceUpper", 0) << 3
+        ) | self._get_field_raw_int(message, "deviceInstanceLower", 0)
+        self.device_function = self._get_field_display_string(message, "deviceFunction")
+        self.device_class = self._get_field_display_string(message, "deviceClass")
+        self.system_instance = self._get_field_raw_int(message, "systemInstance", 0)
+        self.industry_group = self._get_field_display_string(message, "industryGroup")
+        self.arbitrary_address_capable = bool(
+            self._get_field_raw_int(message, "arbitraryAddressCapable", 0)
+        )
+
+    @staticmethod
+    def _get_field_raw_int(
+        message: NMEA2000Message,
+        field_id: str,
+        default: int | None = None,
+    ) -> int:
+        field = message.get_field_by_id(field_id)
+        if isinstance(field.raw_value, int):
+            return field.raw_value
+        if isinstance(field.value, int):
+            return field.value
+        if default is not None:
+            return default
+        raise ValueError(
+            f"PGN: {message.id}: Field with id '{field_id}' does not have an integer raw value."
+        )
+
+    @staticmethod
+    def _get_field_display_string(message: NMEA2000Message, field_id: str) -> str:
+        field = message.get_field_by_id(field_id)
+        if isinstance(field.value, str):
+            return field.value
+        if isinstance(field.raw_value, str):
+            return field.raw_value
+        if isinstance(field.raw_value, int):
+            return str(field.raw_value)
+        if isinstance(field.value, int):
+            return str(field.value)
+        raise ValueError(
+            f"PGN: {message.id}: Field with id '{field_id}' does not have a string display value."
+        )
+
+    @staticmethod
+    def _pack_name_field(value: int, bit_length: int, bit_offset: int, field_name: str) -> int:
+        if value < 0:
+            raise ValueError(f"IsoName field '{field_name}' cannot be negative.")
+        max_value = (1 << bit_length) - 1
+        if value > max_value:
+            raise ValueError(
+                f"IsoName field '{field_name}' value {value} exceeds {bit_length} bits."
+            )
+        return (value & max_value) << bit_offset
+
+    @classmethod
+    def pack_name_from_message(cls, message: NMEA2000Message) -> int:
+        """Pack the ISO Address Claim fields into the canonical 64-bit NAME integer."""
+        return (
+            cls._pack_name_field(cls._get_field_raw_int(message, "uniqueNumber", 0), 21, 0, "uniqueNumber")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "manufacturerCode", 0), 11, 21, "manufacturerCode")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceInstanceLower", 0), 3, 32, "deviceInstanceLower")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceInstanceUpper", 0), 5, 35, "deviceInstanceUpper")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceFunction", 0), 8, 40, "deviceFunction")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "spare", 0), 1, 48, "spare")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "deviceClass", 0), 7, 49, "deviceClass")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "systemInstance", 0), 4, 56, "systemInstance")
+            | cls._pack_name_field(cls._get_field_raw_int(message, "industryGroup", 0), 3, 60, "industryGroup")
+            | cls._pack_name_field(
+                cls._get_field_raw_int(message, "arbitraryAddressCapable", 0),
+                1,
+                63,
+                "arbitraryAddressCapable",
+            )
+        )
+
+    def to_int(self) -> int:
+        """Return the canonical 64-bit ISO NAME integer."""
+        return self.name
 
     def __str__(self) -> str:
         return (

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -348,6 +348,13 @@ def test_iso_address_parse_zero():
     assert isinstance(msg_60928, NMEA2000Message)
     assert msg_60928.source_iso_name is not None
 
+def test_iso_name_pack_name_from_message():
+    decoder = _get_decoder()
+    msg_60928 = decoder.decode("2022-09-10T12:10:16.614Z,6,60928,5,255,8,fb,9b,70,22,00,9b,50,c0", True)
+    assert isinstance(msg_60928, NMEA2000Message)
+    assert msg_60928.source_iso_name is not None
+    assert IsoName.pack_name_from_message(msg_60928) == msg_60928.source_iso_name.name
+
 def test_iso_address_parse_exclude():
     decoder = _get_decoder(exclude_pgns=[60928])
     msg_60928 = decoder.decode("2022-09-10T12:10:16.614Z,6,60928,5,255,8,fb,9b,70,22,00,9b,50,c0", True)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -101,6 +101,15 @@ def _build_group_function_request(source: int, requested_pgn: int, destination: 
     )
 
 
+def _transmit_pgns_from_message(message: NMEA2000Message) -> list[int]:
+    payload = message.get_field_by_id("data").raw_value
+    assert isinstance(payload, bytes)
+    return [
+        int.from_bytes(payload[index : index + 3], byteorder="little", signed=False)
+        for index in range(0, len(payload), 3)
+    ]
+
+
 @pytest.mark.asyncio
 async def test_device_start_claims_address_and_filters_management_messages(tmp_path):
     client = FakeClient()
@@ -315,3 +324,32 @@ async def test_device_product_information_encodes_scaled_nmea_version(tmp_path):
     assert product_information.PGN == 126996
     assert version_field.value == pytest.approx(1.3)
     assert version_field.raw_value == 1300
+
+
+@pytest.mark.asyncio
+async def test_device_pgn_list_always_includes_management_pgns(tmp_path):
+    client = FakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        transmit_pgns=[127250],
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+        await client.emit(_build_iso_request(126464, source=31, destination=255))
+    finally:
+        await device.close()
+
+    pgn_list_message = client.sent_messages[-1]
+    advertised_pgns = set(_transmit_pgns_from_message(pgn_list_message))
+
+    assert pgn_list_message.PGN == 126464
+    assert 127250 in advertised_pgns
+    assert {59392, 59904, 60928, 126208, 126464, 126993, 126996, 126998}.issubset(
+        advertised_pgns
+    )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -210,6 +210,31 @@ async def test_device_conflict_increments_address_when_it_loses(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_device_conflict_keeps_address_when_it_wins(tmp_path):
+    client = FakeClient()
+    device = N2KDevice(
+        client,
+        unique_number=1,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    await device.start()
+    await device.wait_ready(timeout=1)
+    assert device.address == 100
+
+    await client.emit(_build_address_claim(100, unique_number=10))
+    await asyncio.sleep(0.05)
+
+    assert device.address == 100
+    resent_messages = [message for message in client.sent_messages if message.source == 100]
+    assert [message.PGN for message in resent_messages[-2:]] == [60928, 126996]
+    assert not any(message.PGN == 60928 and message.source == 101 for message in client.sent_messages)
+
+
+@pytest.mark.asyncio
 async def test_device_responds_with_iso_nak_and_group_function_ack(tmp_path):
     client = FakeClient()
     device = N2KDevice(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,292 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from nmea2000.device import N2KDevice
+from nmea2000.encoder import NMEA2000Encoder
+from nmea2000.ioclient import State
+from nmea2000.message import NMEA2000Field, NMEA2000Message
+
+
+class FakeClient:
+    def __init__(self):
+        self.state = State.DISCONNECTED
+        self.receive_callback = None
+        self.status_callback = None
+        self.sent_messages: list[NMEA2000Message] = []
+        self.encoder = NMEA2000Encoder()
+
+    def set_receive_callback(self, callback):
+        self.receive_callback = callback
+
+    def set_status_callback(self, callback):
+        self.status_callback = callback
+
+    async def connect(self):
+        self.state = State.CONNECTED
+        if self.status_callback is not None:
+            await self.status_callback(self.state)
+
+    async def close(self):
+        self.state = State.CLOSED
+        if self.status_callback is not None:
+            await self.status_callback(self.state)
+
+    async def send(self, message: NMEA2000Message):
+        self.sent_messages.append(message)
+
+    async def emit(self, message: NMEA2000Message):
+        if self.receive_callback is not None:
+            await self.receive_callback(message)
+
+
+class EncodingFakeClient(FakeClient):
+    async def send(self, message: NMEA2000Message):
+        self.encoder.encode(message)
+        await super().send(message)
+
+
+def _build_iso_request(requested_pgn: int, *, source: int = 10, destination: int = 255) -> NMEA2000Message:
+    return NMEA2000Message(
+        PGN=59904,
+        id="isoRequest",
+        description="ISO Request",
+        source=source,
+        destination=destination,
+        priority=6,
+        timestamp=datetime.now(),
+        fields=[NMEA2000Field("pgn", value=requested_pgn, raw_value=requested_pgn)],
+    )
+
+
+def _build_address_claim(source: int, unique_number: int) -> NMEA2000Message:
+    return NMEA2000Message(
+        PGN=60928,
+        id="isoAddressClaim",
+        description="ISO Address Claim",
+        source=source,
+        destination=255,
+        priority=6,
+        timestamp=datetime.now(),
+        fields=[
+            NMEA2000Field("uniqueNumber", value=unique_number, raw_value=unique_number),
+            NMEA2000Field("manufacturerCode", value=999, raw_value=999),
+            NMEA2000Field("deviceInstanceLower", value=0, raw_value=0),
+            NMEA2000Field("deviceInstanceUpper", value=0, raw_value=0),
+            NMEA2000Field("deviceFunction", value=130, raw_value=130),
+            NMEA2000Field("spare", value=1, raw_value=1),
+            NMEA2000Field("deviceClass", value=25, raw_value=25),
+            NMEA2000Field("systemInstance", value=0, raw_value=0),
+            NMEA2000Field("industryGroup", value=4, raw_value=4),
+            NMEA2000Field("arbitraryAddressCapable", value=1, raw_value=1),
+        ],
+    )
+
+
+def _build_group_function_request(source: int, requested_pgn: int, destination: int) -> NMEA2000Message:
+    return NMEA2000Message(
+        PGN=126208,
+        id="nmeaRequestGroupFunction",
+        description="NMEA - Request group function",
+        source=source,
+        destination=destination,
+        priority=3,
+        timestamp=datetime.now(),
+        fields=[
+            NMEA2000Field("pgn", value=requested_pgn, raw_value=requested_pgn),
+            NMEA2000Field("numberOfParameters", value=0, raw_value=0),
+            NMEA2000Field("parameter", value=0, raw_value=0),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_start_claims_address_and_filters_management_messages(tmp_path):
+    client = FakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    data_messages = asyncio.Queue()
+    raw_messages = asyncio.Queue()
+
+    async def handle_data(message: NMEA2000Message):
+        await data_messages.put(message)
+
+    async def handle_raw(message: NMEA2000Message):
+        await raw_messages.put(message)
+
+    device.set_receive_callback(handle_data)
+    device.set_raw_receive_callback(handle_raw)
+
+    await device.start()
+    await device.wait_ready(timeout=1)
+
+    assert [message.PGN for message in client.sent_messages[:2]] == [59904, 60928]
+    assert device.ready is True
+
+    await client.emit(_build_iso_request(126996, source=31, destination=255))
+    response = client.sent_messages[-1]
+    assert response.PGN == 126996
+    assert data_messages.empty()
+    raw_message = await raw_messages.get()
+    assert raw_message.PGN == 59904
+
+    data_message = NMEA2000Message(PGN=127250, id="vesselHeading", source=44, destination=255, priority=2)
+    await client.emit(data_message)
+    forwarded = await asyncio.wait_for(data_messages.get(), timeout=1)
+    assert forwarded.PGN == 127250
+
+
+@pytest.mark.asyncio
+async def test_device_announces_product_information_on_startup(tmp_path):
+    client = EncodingFakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+    finally:
+        await device.close()
+
+    assert [message.PGN for message in client.sent_messages[:3]] == [59904, 60928, 126996]
+
+
+@pytest.mark.asyncio
+async def test_device_announces_configuration_information_on_startup_when_present(tmp_path):
+    client = EncodingFakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+        installation_description1="Autopilot demo",
+        manufacturer_information="nmea2000 autopilot heading simulator",
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+    finally:
+        await device.close()
+
+    assert [message.PGN for message in client.sent_messages[:4]] == [59904, 60928, 126996, 126998]
+
+
+@pytest.mark.asyncio
+async def test_device_conflict_increments_address_when_it_loses(tmp_path):
+    client = FakeClient()
+    device = N2KDevice(
+        client,
+        unique_number=10,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    await device.start()
+    await device.wait_ready(timeout=1)
+    assert device.address == 100
+
+    await client.emit(_build_address_claim(100, unique_number=1))
+    await asyncio.sleep(0.05)
+
+    assert device.address == 101
+    resent_messages = [message for message in client.sent_messages if message.source == 101]
+    assert [message.PGN for message in resent_messages[-2:]] == [60928, 126996]
+
+
+@pytest.mark.asyncio
+async def test_device_responds_with_iso_nak_and_group_function_ack(tmp_path):
+    client = FakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    await device.start()
+    await device.wait_ready(timeout=1)
+
+    await client.emit(_build_iso_request(130000, source=22, destination=255))
+    iso_nak = client.sent_messages[-1]
+    assert iso_nak.PGN == 59392
+    assert iso_nak.destination == 22
+
+    await client.emit(_build_group_function_request(25, 130000, device.address))
+    group_ack = client.sent_messages[-1]
+    assert group_ack.PGN == 126208
+    assert group_ack.id == "nmeaAcknowledgeGroupFunction"
+    assert group_ack.destination == 25
+
+
+@pytest.mark.asyncio
+async def test_device_heartbeat_messages_encode_with_na_controller_states(tmp_path):
+    client = EncodingFakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=0.01,
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+        await asyncio.sleep(0.05)
+    finally:
+        await device.close()
+
+    heartbeats = [message for message in client.sent_messages if message.PGN == 126993]
+    assert heartbeats
+
+    heartbeat = heartbeats[0]
+    assert heartbeat.get_field_by_id("dataTransmitOffset").value == pytest.approx(0.01)
+    assert heartbeat.get_field_by_id("controller1State").value is None
+    assert heartbeat.get_field_by_id("controller1State").raw_value == 3
+    assert heartbeat.get_field_by_id("controller2State").value is None
+    assert heartbeat.get_field_by_id("controller2State").raw_value == 3
+    assert heartbeat.get_field_int_value_by_id("equipmentStatus") == 0
+    assert heartbeat.get_field_by_id("reserved_30").value is None
+    assert heartbeat.get_field_by_id("reserved_30").raw_value == (1 << 34) - 1
+
+
+@pytest.mark.asyncio
+async def test_device_product_information_encodes_scaled_nmea_version(tmp_path):
+    client = EncodingFakeClient()
+    device = N2KDevice(
+        client,
+        persistence_path=tmp_path / "device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+        await client.emit(_build_iso_request(126996, source=31, destination=255))
+    finally:
+        await device.close()
+
+    product_information = client.sent_messages[-1]
+    version_field = product_information.get_field_by_id("nmea2000Version")
+    assert product_information.PGN == 126996
+    assert version_field.value == pytest.approx(1.3)
+    assert version_field.raw_value == 1300

--- a/tests/test_ioclient.py
+++ b/tests/test_ioclient.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import cast
+
+import can
+import can.message
+import pytest
+
+from nmea2000.device import N2KDevice
+from nmea2000.ioclient import AsyncIOClient, PythonCanAsyncIOClient, State
+from nmea2000.message import NMEA2000Message
+
+
+def _build_message() -> NMEA2000Message:
+    return NMEA2000Message(
+        PGN=127250,
+        id="vesselHeading",
+        source=10,
+        destination=255,
+        priority=2,
+        timestamp=datetime.now(),
+        fields=[],
+    )
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+        self.drain_calls = 0
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        self.drain_calls += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class RecordingClient(AsyncIOClient):
+    def __init__(self, encoded_messages: list[bytes]) -> None:
+        super().__init__(
+            exclude_pgns=[],
+            include_pgns=[],
+            exclude_manufacturer_code=[],
+            include_manufacturer_code=[],
+            preferred_units={},
+            dump_to_file=None,
+            dump_pgns=[],
+            build_network_map=False,
+            seed_network_map=False,
+        )
+        self.encoded_messages = encoded_messages
+
+    async def _connect_impl(self) -> None:
+        return
+
+    async def _receive_impl(self) -> None:
+        return
+
+    def _encode_impl(self, nmea2000Message: NMEA2000Message) -> list[bytes]:
+        return self.encoded_messages
+
+
+class PythonCanSendClient(PythonCanAsyncIOClient):
+    def __init__(self, encoded_message: can.message.Message, **kwargs) -> None:
+        super().__init__("virtual", "test-python-can-send", **kwargs)
+        self.encoded_message = encoded_message
+
+    def _encode_impl(self, nmea2000Message: NMEA2000Message) -> list[can.message.Message]:
+        return [self.encoded_message]
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.sent_messages: list[can.message.Message] = []
+        self.timeouts: list[float | None] = []
+        self.shutdown_called = False
+
+    def send(self, message: can.message.Message, timeout: float | None = None) -> None:
+        self.timeouts.append(timeout)
+        self.sent_messages.append(message)
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+class FlakyBus(FakeBus):
+    def __init__(self, failures_before_success: int, error: can.CanOperationError) -> None:
+        super().__init__()
+        self.failures_before_success = failures_before_success
+        self.error = error
+
+    def send(self, message: can.message.Message, timeout: float | None = None) -> None:
+        self.timeouts.append(timeout)
+        if self.failures_before_success > 0:
+            self.failures_before_success -= 1
+            raise self.error
+        self.sent_messages.append(message)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_client_send_uses_default_stream_send_impl() -> None:
+    client = RecordingClient([b"\x01\x02", b"\x03\x04"])
+    writer = FakeWriter()
+    client.writer = cast(asyncio.StreamWriter, writer)
+
+    try:
+        await client.send(_build_message())
+    finally:
+        await client.close()
+
+    assert writer.writes == [b"\x01\x02", b"\x03\x04"]
+    assert writer.drain_calls == 2
+    assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_python_can_client_send_uses_bus_instead_of_writer() -> None:
+    encoded_message = can.message.Message(
+        arbitration_id=0x19F1120A,
+        is_extended_id=True,
+        data=b"\x01\x02\x03\x04",
+    )
+    client = PythonCanSendClient(encoded_message)
+    bus = FakeBus()
+    client.bus = bus
+
+    try:
+        await client.send(_build_message())
+    finally:
+        await client.close()
+
+    assert bus.sent_messages == [encoded_message]
+    assert bus.shutdown_called is True
+    assert bus.timeouts == [0.1]
+
+
+@pytest.mark.asyncio
+async def test_python_can_client_retries_transient_buffer_pressure() -> None:
+    encoded_message = can.message.Message(
+        arbitration_id=0x19F1120A,
+        is_extended_id=True,
+        data=b"\x01\x02\x03\x04",
+    )
+    client = PythonCanSendClient(
+        encoded_message,
+        send_timeout=0.2,
+        send_retry_count=2,
+        send_retry_delay=0,
+    )
+    bus = FlakyBus(
+        failures_before_success=2,
+        error=can.CanOperationError("Failed to transmit: No buffer space available", 105),
+    )
+    client.bus = bus
+
+    try:
+        await client.send(_build_message())
+    finally:
+        await client.close()
+
+    assert bus.sent_messages == [encoded_message]
+    assert bus.timeouts == [0.2, 0.2, 0.2]
+
+
+@pytest.mark.asyncio
+async def test_python_can_client_raises_persistent_buffer_pressure_without_reconnect() -> None:
+    encoded_message = can.message.Message(
+        arbitration_id=0x19F1120A,
+        is_extended_id=True,
+        data=b"\x01\x02\x03\x04",
+    )
+    client = PythonCanSendClient(
+        encoded_message,
+        send_timeout=0.05,
+        send_retry_count=1,
+        send_retry_delay=0,
+    )
+    bus = FlakyBus(
+        failures_before_success=10,
+        error=can.CanOperationError("Transmit buffer full"),
+    )
+    client.bus = bus
+    client._state = State.CONNECTED
+
+    try:
+        with pytest.raises(can.CanOperationError):
+            await client.send(_build_message())
+        assert client.state == State.CONNECTED
+    finally:
+        await client.close()
+
+    assert client.state == State.CLOSED
+    assert bus.timeouts == [0.05, 0.05]
+
+
+@pytest.mark.asyncio
+async def test_python_can_device_becomes_ready_on_virtual_bus(tmp_path) -> None:
+    device = N2KDevice.for_python_can(
+        "virtual",
+        "test-python-can-ready",
+        persistence_path=tmp_path / "python-can-device.json",
+        address_claim_startup_delay=0,
+        address_claim_detection_time=0.01,
+        heartbeat_interval=3600,
+    )
+
+    try:
+        await device.start()
+        await device.wait_ready(timeout=1)
+        assert device.ready is True
+    finally:
+        await device.close()
+
+    assert device.ready is False


### PR DESCRIPTION
Now for the real reason I wanted all that extended message support!

This PR adds a device API which automatically handles management PGNs so it can be recognised by other devices on the network, modelled off the behaviour of the one in canboatjs.

Also adds the ability to send messages over python-can (it just errored before), and extends IsoName dataclass to allow calculation of `name` based on field values (for address conflict resolution).

All this means a user can do something like this:

```python
import asyncio

from nmea2000.device import N2KDevice
from nmea2000.message import NMEA2000Field, NMEA2000Message


async def handle_received(message: NMEA2000Message) -> None:
    print(f"received PGN {message.PGN} from source {message.source}")


async def main() -> None:
    device = N2KDevice.for_python_can(
        interface="socketcan",
        channel="can0",
        preferred_address=25,
        model_id="Python demo device",
        manufacturer_information="nmea2000 README example",
    )
    device.set_receive_callback(handle_received)

    try:
        await device.start()
        await device.wait_ready(timeout=5)

        await device.send(
            NMEA2000Message(
                PGN=127250,
                id="vesselHeading",
                priority=2,
                source=0,  # 0 means "use the address claimed by this device"
                destination=255,
                fields=[
                    NMEA2000Field(id="sid", raw_value=0),
                    NMEA2000Field(id="heading", value=1.0),
                    NMEA2000Field(id="deviation", raw_value=0),
                    NMEA2000Field(id="variation", raw_value=0),
                    NMEA2000Field(id="reference", raw_value=0),
                    NMEA2000Field(id="reserved_58", raw_value=0),
                ],
            )
        )

        await asyncio.sleep(10)
    finally:
        await device.close()


asyncio.run(main())
```

This heading would show up on other devices on the N2K network - I am currently using it to get heading from pypilot to display on my Garmin GNX20!