### PR TITLE
fix: TextNmea2000Gateway spin-loop at 100% CPU on TCP disconnect

### DIFF
--- a/nmea2000/ioclient.py
+++ b/nmea2000/ioclient.py
@@ -533,6 +533,8 @@ class TextNmea2000Gateway(AsyncIOClient):
     async def _receive_impl(self):
         """Receive a single text line from the TCP connection and decode it."""
         data = await self.reader.readline()
+        if not data:
+            raise ConnectionError("Connection closed by remote host")
         self.logger.debug(f"Received: {data.hex()}")
         line = data.decode('utf-8', errors='ignore').strip()
         try:
@@ -544,6 +546,7 @@ class TextNmea2000Gateway(AsyncIOClient):
         self.logger.debug(f"Received message: {message}")
         if message is not None:
             await self.queue.put(message)
+
 
     def _encode_impl(self, nmea2000Message: NMEA2000Message):
         """Encode a NMEA2000 message using the bound format."""


### PR DESCRIPTION
### Summary
Fixes an infinite busy-spin loop consuming 100% CPU when the remote TCP server closes the connection while using `TextNmea2000Gateway`.

### Root Cause
When the remote TCP host closes the socket connection, `asyncio.StreamReader.readline()` returns an empty byte string `b""` (EOF).

Without checking for empty bytes, `TextNmea2000Gateway._receive_impl()` silently decodes `b""` to `""`, fails parsing, logs a warning, and returns normally. `_receive_loop()` then repeatedly calls `_receive_impl()` in an unthrottled infinite loop, consuming 100% CPU on a single core until the client process is terminated.

### Solution
Raise `ConnectionError("Connection closed by remote host")` when `readline()` returns `b""`. 

This brings `TextNmea2000Gateway` in line with `ActisenseBstNmea2000Gateway._receive_impl()`, which already correctly implements this exact EOF check.

### Reproducer
Connect `TextNmea2000Gateway` to any serial-to-TCP bridge or gateway, then restart/stop the TCP server. The client application process will immediately lock at 100% CPU load.